### PR TITLE
CMakeLists changes to fix undefined symbol error.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ qt_wrap_cpp(MOC_FILES
 ## the previous command which is stored in ``${MOC_FILES}``.
 set(SOURCE_FILES
   src/tf_visual_tools_gui.cpp
+  ${MOC_FILES}
 )
 
 add_library(${PROJECT_NAME}_receiver src/gui_remote_receiver.cpp)


### PR DESCRIPTION
Adding the `MOC_FILES` variable when setting `SOURCE_FILES` fixes the undefined symbol error referenced in #6, which I was also experiencing on Melodic/QT5.

Thanks for putting this tool together!